### PR TITLE
bug: corrigido quebra de layout em resolucoes pequenas

### DIFF
--- a/MyWebPortifolio/frontend/src/App.css
+++ b/MyWebPortifolio/frontend/src/App.css
@@ -1,9 +1,8 @@
 #root {
   width: 100%;
-  max-width: 100%; /* MATAMOS A TRAVA DE 1280px AQUI! */
+  max-width: 100%; 
   margin: 0;
-  padding: 0;      /* TIRAMOS O ESPAÇAMENTO INVISÍVEL */
-  text-align: left;/* VOLTAMOS O TEXTO PRO PADRÃO */
+  padding: 0;     
 }
 
 .logo {

--- a/MyWebPortifolio/frontend/src/index.css
+++ b/MyWebPortifolio/frontend/src/index.css
@@ -22,15 +22,7 @@ a:hover {
   color: #535bf2;
 }
 
-body {
-  margin: 0;
-  padding: 0;
-  width: 100%;
-  min-width: 320px;
-  min-height: 100vh;
-  /* 👇 APAGAMOS O DISPLAY: FLEX E PLACE-ITEMS: CENTER */
-  display: block; 
-}
+
 h1 {
   font-size: 3.2em;
   line-height: 1.1;

--- a/MyWebPortifolio/frontend/src/paginas/MainLayout.jsx
+++ b/MyWebPortifolio/frontend/src/paginas/MainLayout.jsx
@@ -40,7 +40,7 @@ const MainLayout = () => {
 
   return (
     // 👉 RESTAURADO: Sua classe original "container"
-    <div className="container">
+    <div className="layout-wrapper">
       <Header
         isAuthenticated={isAuthenticated}
         userName={userName}

--- a/MyWebPortifolio/frontend/src/styles/about.css
+++ b/MyWebPortifolio/frontend/src/styles/about.css
@@ -21,10 +21,13 @@
    ========================================= */
 .code-comment {
   display: block;
-  color: #6272a4; /* Cor clássica de comentário de código (Tema Dracula) */
+  color: #6272a4; 
   font-family: 'Courier New', Courier, monospace;
   font-size: 0.95rem;
   margin-bottom: 8px;
+  word-break: break-all; 
+  overflow-wrap: anywhere;
+  white-space: pre-wrap; 
 }
 
 .about-header h2 {
@@ -148,5 +151,18 @@
   
   .about-pillars {
     grid-template-columns: 1fr; /* Pilares ficam um embaixo do outro no celular */
+  }
+}
+@media (max-width: 480px) {
+  .about-section {
+    padding: 15px !important; /* Devolve espaço de leitura para o usuário */
+  }
+  
+  .about-header h2 {
+    font-size: 1.5rem; /* Evita que o título vaze */
+  }
+
+  .code-comment {
+    font-size: 0.8rem; /* Código ligeiramente menor */
   }
 }

--- a/MyWebPortifolio/frontend/src/styles/global.css
+++ b/MyWebPortifolio/frontend/src/styles/global.css
@@ -3,6 +3,14 @@
   margin: 0;
   padding: 0;
   box-sizing: border-box;
+  min-width: 0; /* 👈 NOVO: Impede que textos ou botões forcem o layout a esticar */
+}
+
+/* 👈 NOVO: A Trava Mestra contra o buraco lateral */
+html, body {
+  width: 100%;
+  max-width: 100vw;
+  overflow-x: hidden; /* Corta tudo que tentar vazar da tela */
 }
 
 body {

--- a/MyWebPortifolio/frontend/src/styles/home.css
+++ b/MyWebPortifolio/frontend/src/styles/home.css
@@ -98,10 +98,22 @@
    8. RESPONSIVIDADE (CELULAR E TABLET)
    ========================================= */
 @media (max-width: 1024px) {
-  .content {
-    flex-direction: column; 
-    gap: 30px;
-  }
+  .main-container {
+  width: 100%;
+  max-width: 100%; /* 👈 Impede de crescer além do pai */
+  box-sizing: border-box; /* 👈 Garante que paddings não somem na largura */
+  backdrop-filter: blur(16px);
+  border-radius: 20px;
+  color: #e2e8f0;
+}
+ .content {
+  display: flex;
+  flex-direction: row; 
+  align-items: flex-start; 
+  gap: 40px; 
+  width: 100%;
+  max-width: 100vw; /* 👈 Trava de segurança */
+}
   .sidebar-wrapper {
     display: none; 
   }
@@ -112,5 +124,31 @@
   .separator {
     margin: 40px auto; /* Reduz a distância no mobile */
     width: 95%;
+  }
+}
+  
+@media (max-width: 320px) {
+  .main-container {
+  width: 100%;
+  max-width: 100%; /* 👈 Impede de crescer além do pai */
+  box-sizing: border-box; /* 👈 Garante que paddings não somem na largura */
+  backdrop-filter: blur(16px);
+  color: #e2e8f0;
+}
+ .content {
+  display: flex;
+  flex-direction: row; 
+  align-items: flex-start; 
+  width: 100%;
+  max-width: 100vw; /* 👈 Trava de segurança */
+}
+  .sidebar-wrapper {
+    display: none; 
+  }
+  .main-container {
+    border-radius: 12px;
+  }
+  .separator {
+    width: 100%;
   }
 }

--- a/MyWebPortifolio/frontend/src/styles/mainlayout.css
+++ b/MyWebPortifolio/frontend/src/styles/mainlayout.css
@@ -2,23 +2,22 @@
    MAIN LAYOUT (Estrutura Global)
    ========================================= */
 
-/* 👉 CORRIGIDO: Agora o CSS conversa com o JSX (layout-wrapper) */
 .layout-wrapper {
   background-color: rgba(18, 18, 18, 0.65);
   position: relative;
-  width: 70%; /* O comprimido de 70% */
+  width: 70%; 
   max-width: 1400px;
-  margin: 0 auto; /* Centraliza no monitor */
+  margin: 0 auto; 
   padding: 30px 20px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  min-height: 100vh; /* Faz a página ter pelo menos a altura do monitor */
+  min-height: 100vh;
 }
 
 .layout-main-content {
-  width: 100%; /* Respeita os 70% do pai */
-  flex: 1; /* Empurra o footer pro final */
+  width: 100%; 
+  flex: 1; 
   display: flex;
   flex-direction: column;
   padding: 20px 0; 
@@ -27,9 +26,29 @@
 /* =========================================
    RESPONSIVIDADE GLOBAL
    ========================================= */
+@media (max-width: 1335px) {
+  .layout-wrapper {
+    width: 85%; /* Expande no celular */
+    padding: 20px 10px;
+  }
+}
+
 @media (max-width: 1024px) {
   .layout-wrapper {
     width: 95%; /* Expande no celular */
     padding: 20px 10px;
   }
+}
+@media (max-width: 460px) {
+  .layout-wrapper {
+    width: 100%; /* Expande no celular */
+    padding: 0px;
+  }
+  .layout-main-content {
+  display: flex;
+  flex-direction: row; 
+  align-items: flex-start; 
+  gap: 40px; 
+  width: 100%;
+}
 }


### PR DESCRIPTION
closes #10 

Ajuste de layout em versões mobiles na pagina home, onde alguns componentes ficavam bugados e quebrados como abaixo:
<img width="749" height="1175" alt="image" src="https://github.com/user-attachments/assets/879d4c0e-af0a-451e-9d5d-71a53892f5b8" />

O ajuste deste PR resolve este bug.

<img width="598" height="1152" alt="image" src="https://github.com/user-attachments/assets/0f22fc05-a83c-4626-a2b2-e2c5a830c583" />
