### PR TITLE
fix: replace broken/expired icon URLs in Skills component

### DIFF
--- a/MyWebPortifolio/frontend/src/components/home/Skills.jsx
+++ b/MyWebPortifolio/frontend/src/components/home/Skills.jsx
@@ -2,21 +2,21 @@ import React from "react";
 import "../../styles/skills.css";
 
 const coreStack = [
-  { src: "https://cdn-icons-png.flaticon.com/512/226/226777.png", name: "Java 21" },
-  { src: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR9WYHLYIVN011VGVl1pkwPRrAGWPBbG25YrQ&s", name: "Spring Boot" },
-  { src: "https://media.licdn.com/dms/image/v2/D4E12AQF64SYsV08fkA/article-cover_image-shrink_600_2000/article-cover_image-shrink_600_2000/0/1662093619580?e=2147483647&v=beta&t=uoidKIOEIH0ZlboxixU1Lfkg5rPnYoCizMrA7P-YVQ4", name: "PostgreSQL" },
-  { src: "https://images.sftcdn.net/images/t_app-icon-m/p/917c77e8-96d1-11e6-8453-00163ed833e7/3780880766/mysql-com-icon.png", name: "MySQL" },
-  { src: "https://cdn-icons-png.flaticon.com/512/919/919853.png", name: "Docker" },
+  { src: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/java/java-original.svg", name: "Java 21" },
+  { src: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/spring/spring-original.svg", name: "Spring Boot" },
+  { src: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/postgresql/postgresql-original.svg", name: "PostgreSQL" },
+  { src: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/mysql/mysql-original.svg", name: "MySQL" },
+  { src: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/docker/docker-original.svg", name: "Docker" },
   { src: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/93/Amazon_Web_Services_Logo.svg/1200px-Amazon_Web_Services_Logo.svg.png", name: "AWS" },
 ];
 
 const complementStack = [
-  { src: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRuHnJDLOcdm_0b6N6kNj-1OvO9KhKYgqIy0w&s", name: "React" },
-  { src: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/61/HTML5_logo_and_wordmark.svg/1200px-HTML5_logo_and_wordmark.svg.png", name: "HTML5" },
-  { src: "https://cdn.pixabay.com/photo/2016/11/19/23/00/css3-1841590_1280.png", name: "CSS3" },
-  { src: "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Typescript_logo_2020.svg/1200px-Typescript_logo_2020.svg.png", name: "TypeScript" },
-  { src: "https://git-scm.com/images/logos/downloads/Git-Icon-Color.png", name: "Git" },
-  { src: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/Git_icon.svg/2048px-Git_icon.svg.png", name: "GitHub" },
+  { src: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/react/react-original.svg", name: "React" },
+  { src: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/html5/html5-original.svg", name: "HTML5" },
+  { src: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/css3/css3-original.svg", name: "CSS3" },
+  { src: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg", name: "TypeScript" },
+  { src: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/git/git-original.svg", name: "Git" },
+  { src: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/github/github-original.svg", name: "GitHub" },
 ];
 
 const expertise = [


### PR DESCRIPTION
Substitui URLs de ícones corrompidos por referências confiáveis via jsDelivr (devicons).

URLs removidas:
- encrypted-tbn0.gstatic.com (thumbnails Google que expiram) → Spring Boot e React
- media.licdn.com (CDN LinkedIn com autenticação) → PostgreSQL
- images.sftcdn.net (CDN terceiro instável) → MySQL
- git_icon.svg do Wikimedia (ícone errado) → GitHub estava usando ícone do Git

Todas as imagens agora apontam para cdn.jsdelivr.net/gh/devicons/devicon@latest, mantendo apenas o SVG do AWS via Wikimedia (já funcional).