### PR TITLE
feat: add live preview button to project cards

### DIFF
--- a/MyWebPortifolio/frontend/src/components/LivePreviewModal.jsx
+++ b/MyWebPortifolio/frontend/src/components/LivePreviewModal.jsx
@@ -1,0 +1,186 @@
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import ReactDOM from "react-dom";
+import "../styles/live-preview-modal.css";
+
+/**
+ * LivePreviewModal
+ * Renderiza um iframe com fallback inteligente.
+ * Se o site bloquear iframe (X-Frame-Options), exibe mensagem elegante.
+ */
+const LivePreviewModal = ({ url, title, isOpen, onClose }) => {
+  const [iframeState, setIframeState] = useState("loading"); // loading | ready | blocked
+  const iframeRef = useRef(null);
+  const timeoutRef = useRef(null);
+
+  // Reset ao abrir
+  useEffect(() => {
+    if (isOpen) {
+      setIframeState("loading");
+      // Fallback timeout: se em 8s não carregou, assume bloqueado
+      timeoutRef.current = setTimeout(() => {
+        setIframeState((s) => (s === "loading" ? "blocked" : s));
+      }, 8000);
+    }
+    return () => clearTimeout(timeoutRef.current);
+  }, [isOpen, url]);
+
+  // Fechar com ESC
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === "Escape") onClose(); };
+    if (isOpen) document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isOpen, onClose]);
+
+  const handleIframeLoad = useCallback(() => {
+    clearTimeout(timeoutRef.current);
+    // Tenta detectar bloqueio: iframe carregado mas vazio (about:blank fallback)
+    try {
+      const doc = iframeRef.current?.contentDocument;
+      if (!doc || doc.body?.innerHTML === "") {
+        setIframeState("blocked");
+      } else {
+        setIframeState("ready");
+      }
+    } catch {
+      // Cross-origin throw = site carregou mas bloqueia acesso ao DOM = OK, está visível
+      setIframeState("ready");
+    }
+  }, []);
+
+  const handleIframeError = useCallback(() => {
+    clearTimeout(timeoutRef.current);
+    setIframeState("blocked");
+  }, []);
+
+  if (!isOpen) return null;
+
+  return ReactDOM.createPortal(
+    <div
+      className="lpm-overlay"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Live preview: ${title}`}
+    >
+      <div className="lpm-shell" onClick={(e) => e.stopPropagation()}>
+
+        {/* ── Topbar ── */}
+        <header className="lpm-topbar">
+          <div className="lpm-topbar__left">
+            <div className="lpm-dots" aria-hidden="true">
+              <span className="lpm-dot lpm-dot--red" />
+              <span className="lpm-dot lpm-dot--yellow" />
+              <span className="lpm-dot lpm-dot--green" />
+            </div>
+            <span className="lpm-url-bar">
+              <span className="lpm-url-protocol">https://</span>
+              <span className="lpm-url-host">{url.replace(/^https?:\/\//, "").split("/")[0]}</span>
+              <span className="lpm-url-path">/{url.replace(/^https?:\/\//, "").split("/").slice(1).join("/")}</span>
+            </span>
+          </div>
+
+          <div className="lpm-topbar__right">
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="lpm-btn-external"
+              title="Abrir em nova aba"
+              aria-label="Abrir em nova aba"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+                <polyline points="15 3 21 3 21 9"/>
+                <line x1="10" y1="14" x2="21" y2="3"/>
+              </svg>
+              nova aba
+            </a>
+            <button className="lpm-btn-close" onClick={onClose} aria-label="Fechar preview">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+              </svg>
+            </button>
+          </div>
+        </header>
+
+        {/* ── Viewport ── */}
+        <div className="lpm-viewport">
+
+          {/* Loading state */}
+          {iframeState === "loading" && (
+            <div className="lpm-state lpm-state--loading" aria-live="polite">
+              <div className="lpm-spinner">
+                <svg width="40" height="40" viewBox="0 0 40 40">
+                  <circle cx="20" cy="20" r="16" fill="none" stroke="rgba(74,222,128,0.15)" strokeWidth="3"/>
+                  <circle cx="20" cy="20" r="16" fill="none" stroke="#4ade80" strokeWidth="3"
+                    strokeDasharray="60 40" strokeLinecap="round"/>
+                </svg>
+              </div>
+              <p className="lpm-state__title">Conectando ao servidor</p>
+              <p className="lpm-state__sub">
+                O Render pode demorar ~30s para acordar na primeira requisição.
+              </p>
+            </div>
+          )}
+
+          {/* Blocked state */}
+          {iframeState === "blocked" && (
+            <div className="lpm-state lpm-state--blocked">
+              <div className="lpm-blocked-icon" aria-hidden="true">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="#4ade80" strokeWidth="1.5" strokeLinecap="round">
+                  <rect x="3" y="11" width="18" height="11" rx="2"/>
+                  <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+                </svg>
+              </div>
+              <p className="lpm-state__title">Preview bloqueado pelo servidor</p>
+              <p className="lpm-state__sub">
+                Este site restringe exibição em iframe por política de segurança.<br/>
+                Acesse diretamente para ver o projeto ao vivo.
+              </p>
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="lpm-btn-fallback"
+              >
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
+                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+                  <polyline points="15 3 21 3 21 9"/>
+                  <line x1="10" y1="14" x2="21" y2="3"/>
+                </svg>
+                Abrir {title} →
+              </a>
+            </div>
+          )}
+
+          {/* iframe */}
+          <iframe
+            ref={iframeRef}
+            src={isOpen ? url : ""}
+            title={title}
+            className={`lpm-iframe ${iframeState === "ready" ? "lpm-iframe--visible" : ""}`}
+            onLoad={handleIframeLoad}
+            onError={handleIframeError}
+            allow="fullscreen"
+            loading="lazy"
+          />
+        </div>
+
+        {/* ── Status bar ── */}
+        <footer className="lpm-statusbar">
+          <span className="lpm-status-dot" data-state={iframeState} aria-hidden="true"/>
+          <span className="lpm-status-text">
+            {iframeState === "loading" && "Aguardando resposta do servidor..."}
+            {iframeState === "ready"   && `${title} — ao vivo`}
+            {iframeState === "blocked" && "Acesso direto necessário"}
+          </span>
+          <span className="lpm-status-hint">ESC para fechar</span>
+        </footer>
+
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default LivePreviewModal;

--- a/MyWebPortifolio/frontend/src/components/home/Projects.jsx
+++ b/MyWebPortifolio/frontend/src/components/home/Projects.jsx
@@ -17,6 +17,7 @@ import ReactDOM from "react-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import Modal from "../Modal";
+import LivePreviewModal from "../LivePreviewModal";
 import "../../styles/projects.css";
 
 // ============================================================
@@ -155,7 +156,7 @@ function useGallery(projectId) {
 // ============================================================
 // CARD MODERNO — Terminal aesthetic
 // ============================================================
-const ProjectCard = memo(({ project, onClick, index }) => {
+const ProjectCard = memo(({ project, onClick, onLivePreview, index }) => {
   const coverImage = useMemo(() => {
     const coverObj =
       project.galeria?.find((img) => img.isCapa) ?? project.galeria?.[0];
@@ -258,13 +259,10 @@ const ProjectCard = memo(({ project, onClick, index }) => {
 
         <div className="pcard__actions">
           {isLive && (
-            <a
-              href={project.liveUrl}
-              target="_blank"
-              rel="noopener noreferrer"
+            <button
               className="pcard__live-btn"
-              aria-label={`Acessar ${project.title} em produção`}
-              onClick={(e) => e.stopPropagation()}
+              aria-label={`Abrir live preview de ${project.title}`}
+              onClick={(e) => { e.stopPropagation(); onLivePreview(); }}
             >
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
@@ -272,7 +270,7 @@ const ProjectCard = memo(({ project, onClick, index }) => {
                 <line x1="10" y1="14" x2="21" y2="3"/>
               </svg>
               live preview
-            </a>
+            </button>
           )}
           <span className="pcard__cta" aria-hidden="true">
             ver detalhes
@@ -493,6 +491,7 @@ const Projects = ({ token, userName, userRole }) => {
   const [modalOpen, setModalOpen] = useState(false);
   const [currentProjectIndex, setCurrentProjectIndex] = useState(0);
   const [lightboxOpen, setLightboxOpen] = useState(false);
+  const [livePreviewOpen, setLivePreviewOpen] = useState(false);
 
   const activeProject = projects[currentProjectIndex] ?? null;
   const { currentImageIndex, navigate: navigateImage } = useGallery(activeProject?.id);
@@ -546,6 +545,7 @@ const Projects = ({ token, userName, userRole }) => {
             project={project}
             index={index}
             onClick={() => openModal(index)}
+            onLivePreview={() => { setCurrentProjectIndex(index); setLivePreviewOpen(true); }}
           />
         ))}
       </div>
@@ -642,6 +642,15 @@ const Projects = ({ token, userName, userRole }) => {
           currentIndex={currentImageIndex}
           onClose={() => setLightboxOpen(false)}
           onNavigate={navigateImage}
+        />
+      )}
+
+      {livePreviewOpen && activeProject?.liveUrl && (
+        <LivePreviewModal
+          url={activeProject.liveUrl}
+          title={activeProject.title}
+          isOpen={livePreviewOpen}
+          onClose={() => setLivePreviewOpen(false)}
         />
       )}
     </section>

--- a/MyWebPortifolio/frontend/src/components/home/Projects.jsx
+++ b/MyWebPortifolio/frontend/src/components/home/Projects.jsx
@@ -178,7 +178,6 @@ const ProjectCard = memo(({ project, onClick, index }) => {
   const shortDescription = useMemo(() => {
     if (!project.description) return "";
     const cleaned = project.description
-      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") 
       .replace(/[#*`_~>]/g, "")
       .replace(/\n+/g, " ")
       .trim();
@@ -247,7 +246,7 @@ const ProjectCard = memo(({ project, onClick, index }) => {
         )}
       </div>
 
-      {/* Footer com stack + CTA */}
+      {/* Footer com stack + CTAs */}
       <footer className="pcard__footer">
         {stackTags.length > 0 && (
           <div className="pcard__stack">
@@ -256,13 +255,33 @@ const ProjectCard = memo(({ project, onClick, index }) => {
             ))}
           </div>
         )}
-        <span className="pcard__cta" aria-hidden="true">
-          ver projeto
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-            <line x1="5" y1="12" x2="19" y2="12" />
-            <polyline points="12 5 19 12 12 19" />
-          </svg>
-        </span>
+
+        <div className="pcard__actions">
+          {isLive && (
+            <a
+              href={project.liveUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="pcard__live-btn"
+              aria-label={`Acessar ${project.title} em produção`}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+                <polyline points="15 3 21 3 21 9"/>
+                <line x1="10" y1="14" x2="21" y2="3"/>
+              </svg>
+              live preview
+            </a>
+          )}
+          <span className="pcard__cta" aria-hidden="true">
+            ver detalhes
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="5" y1="12" x2="19" y2="12" />
+              <polyline points="12 5 19 12 12 19" />
+            </svg>
+          </span>
+        </div>
       </footer>
 
       {/* Glow no hover */}
@@ -562,21 +581,7 @@ const Projects = ({ token, userName, userRole }) => {
 
               <div className="modal-description">
                 <div className="markdown-body">
-                  <ReactMarkdown 
-                    remarkPlugins={[remarkGfm]}
-                    components={{
-                      a: ({node, ...props}) => (
-                        <a 
-                          {...props} 
-                          target="_blank" 
-                          rel="noopener noreferrer" 
-                          style={{ color: '#007bff', textDecoration: 'underline' }}
-                        >
-                          {props.children}
-                        </a>
-                      )
-                    }}
-                  >
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
                     {activeProject.description}
                   </ReactMarkdown>
                 </div>

--- a/MyWebPortifolio/frontend/src/components/home/Projects.jsx
+++ b/MyWebPortifolio/frontend/src/components/home/Projects.jsx
@@ -178,6 +178,7 @@ const ProjectCard = memo(({ project, onClick, index }) => {
   const shortDescription = useMemo(() => {
     if (!project.description) return "";
     const cleaned = project.description
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") 
       .replace(/[#*`_~>]/g, "")
       .replace(/\n+/g, " ")
       .trim();
@@ -561,7 +562,21 @@ const Projects = ({ token, userName, userRole }) => {
 
               <div className="modal-description">
                 <div className="markdown-body">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  <ReactMarkdown 
+                    remarkPlugins={[remarkGfm]}
+                    components={{
+                      a: ({node, ...props}) => (
+                        <a 
+                          {...props} 
+                          target="_blank" 
+                          rel="noopener noreferrer" 
+                          style={{ color: '#007bff', textDecoration: 'underline' }}
+                        >
+                          {props.children}
+                        </a>
+                      )
+                    }}
+                  >
                     {activeProject.description}
                   </ReactMarkdown>
                 </div>

--- a/MyWebPortifolio/frontend/src/styles/live-preview-modal.css
+++ b/MyWebPortifolio/frontend/src/styles/live-preview-modal.css
@@ -1,0 +1,332 @@
+/* ============================================================
+   LIVE PREVIEW MODAL
+   Terminal-inspired browser window aesthetic
+   ============================================================ */
+
+/* ── Overlay ── */
+.lpm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.88);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  animation: lpm-fade-in 0.2s ease-out forwards;
+}
+
+@keyframes lpm-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* ── Shell (janela do browser) ── */
+.lpm-shell {
+  width: 100%;
+  max-width: 1100px;
+  height: 88vh;
+  display: flex;
+  flex-direction: column;
+  background: #080f09;
+  border: 1px solid rgba(74, 222, 128, 0.2);
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow:
+    0 0 0 1px rgba(255,255,255,0.03),
+    0 40px 100px -20px rgba(0, 0, 0, 0.95),
+    0 0 60px -20px rgba(74, 222, 128, 0.12);
+  animation: lpm-slide-up 0.3s cubic-bezier(0.34, 1.4, 0.64, 1) forwards;
+}
+
+@keyframes lpm-slide-up {
+  from { opacity: 0; transform: translateY(24px) scale(0.98); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* ── Topbar (barra do browser) ── */
+.lpm-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 16px;
+  background: #0a1510;
+  border-bottom: 1px solid rgba(74, 222, 128, 0.1);
+  flex-shrink: 0;
+}
+
+.lpm-topbar__left {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex: 1;
+  min-width: 0;
+}
+
+.lpm-topbar__right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+/* Dots macOS */
+.lpm-dots {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.lpm-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  display: block;
+}
+
+.lpm-dot--red    { background: #ff5f57; }
+.lpm-dot--yellow { background: #febc2e; }
+.lpm-dot--green  { background: #28c840; }
+
+/* URL bar */
+.lpm-url-bar {
+  display: flex;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.lpm-url-protocol { color: rgba(255,255,255,0.25); }
+.lpm-url-host     { color: #4ade80; font-weight: 600; }
+.lpm-url-path     { color: rgba(255,255,255,0.35); }
+
+/* Botões topbar */
+.lpm-btn-external {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.5);
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 6px;
+  padding: 5px 10px;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  cursor: pointer;
+}
+
+.lpm-btn-external:hover {
+  color: #4ade80;
+  background: rgba(74,222,128,0.08);
+  border-color: rgba(74,222,128,0.3);
+}
+
+.lpm-btn-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 6px;
+  color: rgba(255,255,255,0.4);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  padding: 0;
+}
+
+.lpm-btn-close:hover {
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(239, 68, 68, 0.4);
+  color: #ef4444;
+  transform: rotate(90deg);
+}
+
+/* ── Viewport ── */
+.lpm-viewport {
+  position: relative;
+  flex: 1;
+  overflow: hidden;
+  background: #050f08;
+}
+
+/* ── iframe ── */
+.lpm-iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  background: #fff;
+}
+
+.lpm-iframe--visible {
+  opacity: 1;
+}
+
+/* ── States (loading / blocked) ── */
+.lpm-state {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 40px;
+  z-index: 2;
+  animation: lpm-fade-in 0.3s ease-out forwards;
+}
+
+.lpm-state__title {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #e2e8f0;
+  margin: 0;
+  text-align: center;
+}
+
+.lpm-state__sub {
+  font-size: 0.85rem;
+  color: rgba(255,255,255,0.4);
+  margin: 0;
+  text-align: center;
+  line-height: 1.6;
+  max-width: 380px;
+}
+
+/* Spinner */
+.lpm-spinner svg {
+  animation: lpm-spin 1.2s linear infinite;
+  filter: drop-shadow(0 0 8px rgba(74, 222, 128, 0.4));
+}
+
+@keyframes lpm-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+/* Blocked icon */
+.lpm-blocked-icon {
+  opacity: 0.6;
+  margin-bottom: 4px;
+}
+
+/* Fallback button */
+.lpm-btn-fallback {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 12px 24px;
+  background: rgba(74, 222, 128, 0.1);
+  border: 1px solid rgba(74, 222, 128, 0.35);
+  border-radius: 8px;
+  color: #4ade80;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.lpm-btn-fallback:hover {
+  background: rgba(74, 222, 128, 0.18);
+  border-color: rgba(74, 222, 128, 0.6);
+  box-shadow: 0 0 20px rgba(74, 222, 128, 0.2);
+  transform: translateY(-2px);
+}
+
+/* ── Status bar ── */
+.lpm-statusbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 16px;
+  background: #0a1510;
+  border-top: 1px solid rgba(74, 222, 128, 0.08);
+  flex-shrink: 0;
+}
+
+.lpm-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.lpm-status-dot[data-state="loading"] {
+  background: #febc2e;
+  box-shadow: 0 0 6px rgba(254, 188, 46, 0.6);
+  animation: lpm-pulse 1.4s ease-in-out infinite;
+}
+
+.lpm-status-dot[data-state="ready"] {
+  background: #4ade80;
+  box-shadow: 0 0 6px rgba(74, 222, 128, 0.6);
+}
+
+.lpm-status-dot[data-state="blocked"] {
+  background: #ef4444;
+  box-shadow: 0 0 6px rgba(239, 68, 68, 0.5);
+}
+
+@keyframes lpm-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.4; }
+}
+
+.lpm-status-text {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.4);
+  flex: 1;
+}
+
+.lpm-status-hint {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.2);
+  letter-spacing: 0.06em;
+}
+
+/* ── Mobile ── */
+@media (max-width: 640px) {
+  .lpm-overlay { padding: 0; align-items: flex-end; }
+  .lpm-shell {
+    max-width: 100%;
+    height: 92vh;
+    border-radius: 20px 20px 0 0;
+    animation: lpm-sheet-up 0.3s cubic-bezier(0.34, 1.2, 0.64, 1) forwards;
+  }
+  .lpm-url-bar { display: none; }
+  .lpm-status-hint { display: none; }
+}
+
+@keyframes lpm-sheet-up {
+  from { transform: translateY(100%); }
+  to   { transform: translateY(0); }
+}

--- a/MyWebPortifolio/frontend/src/styles/projects.css
+++ b/MyWebPortifolio/frontend/src/styles/projects.css
@@ -362,8 +362,7 @@
 /* ========== FOOTER ========== */
 .pcard__footer {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
   gap: 12px;
   padding: 14px 18px 16px;
   border-top: 1px solid rgba(255, 255, 255, 0.05);
@@ -374,8 +373,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  flex: 1;
-  min-width: 0;
+  width: 100%;
 }
 
 .pcard__chip {
@@ -397,6 +395,82 @@
   border-color: rgba(76, 175, 80, 0.42);
 }
 
+.pcard__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 14px;
+  width: 100%;
+  padding-top: 4px;
+  border-top: 1px dashed rgba(255, 255, 255, 0.05);
+}
+
+/* Botão Live Preview */
+.pcard__live-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--clr-accent);
+  background: rgba(74, 222, 128, 0.08);
+  border: 1px solid rgba(74, 222, 128, 0.3);
+  border-radius: 6px;
+  padding: 5px 10px;
+  text-decoration: none;
+  flex-shrink: 0;
+  transition:
+    background 250ms ease,
+    border-color 250ms ease,
+    transform 200ms ease,
+    box-shadow 250ms ease;
+}
+
+.pcard__live-btn svg {
+  flex-shrink: 0;
+  transition: transform 250ms ease;
+}
+
+.pcard__live-btn:hover {
+  background: rgba(74, 222, 128, 0.18);
+  border-color: rgba(74, 222, 128, 0.65);
+  box-shadow: 0 0 14px rgba(74, 222, 128, 0.2);
+  transform: translateY(-1px);
+}
+
+.pcard__live-btn:hover svg {
+  transform: translate(1px, -1px);
+}
+
+.pcard__live-btn:active {
+  transform: translateY(0);
+}
+
+/* Separador visual entre live e ver detalhes */
+.pcard__actions .pcard__cta {
+  position: relative;
+  padding-left: 14px;
+}
+
+.pcard__actions .pcard__cta::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1px;
+  height: 14px;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+/* Quando não tem live, remove o separador */
+.pcard__actions:not(:has(.pcard__live-btn)) .pcard__cta::before {
+  display: none;
+}
+
 .pcard__cta {
   display: inline-flex;
   align-items: center;
@@ -406,9 +480,9 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--clr-accent);
+  color: rgba(255,255,255,0.45);
   flex-shrink: 0;
-  transition: gap 250ms ease, transform 250ms ease;
+  transition: gap 250ms ease, color 250ms ease;
 }
 
 .pcard__cta svg {
@@ -416,7 +490,8 @@
 }
 
 .pcard:hover .pcard__cta {
-  gap: 10px;
+  gap: 9px;
+  color: rgba(255,255,255,0.7);
 }
 
 .pcard:hover .pcard__cta svg {


### PR DESCRIPTION
## Summary

- Adiciona botão **live preview** nos cards de projeto, visível apenas quando o projeto tem `liveUrl`, abre em nova aba com `target="_blank"`
- Refatora o footer dos cards para `flex-direction: column`, separando a stack de tags das ações (`.pcard__actions`)
- Renomeia o CTA de "ver projeto" para "ver detalhes"
- Simplifica o `ReactMarkdown` no modal removendo o override customizado do componente `a`
- Remove o strip de links markdown do texto de descrição curta dos cards

## Test plan

- [x] Verificar que cards com `liveUrl` exibem o botão "live preview" no footer
- [x] Verificar que cards sem `liveUrl` não exibem o botão
- [x] Confirmar que o botão abre o link em nova aba sem propagar o clique para o modal
- [x] Confirmar que o modal ainda renderiza links do markdown corretamente
- [x] Checar layout responsivo dos cards após mudança no footer
