### PR TITLE
fix: LivePreviewModal — corrigir detecção de bloqueio e melhorar UX

### DIFF
--- a/MyWebPortifolio/frontend/src/components/LivePreviewModal.jsx
+++ b/MyWebPortifolio/frontend/src/components/LivePreviewModal.jsx
@@ -16,10 +16,10 @@ const LivePreviewModal = ({ url, title, isOpen, onClose }) => {
   useEffect(() => {
     if (isOpen) {
       setIframeState("loading");
-      // Fallback timeout: se em 8s não carregou, assume bloqueado
+      // Timeout: se onLoad não disparar em 8s, assume bloqueado (ex: net::ERR sem onError)
       timeoutRef.current = setTimeout(() => {
         setIframeState((s) => (s === "loading" ? "blocked" : s));
-      }, 8000);
+      }, 60000);
     }
     return () => clearTimeout(timeoutRef.current);
   }, [isOpen, url]);
@@ -33,18 +33,7 @@ const LivePreviewModal = ({ url, title, isOpen, onClose }) => {
 
   const handleIframeLoad = useCallback(() => {
     clearTimeout(timeoutRef.current);
-    // Tenta detectar bloqueio: iframe carregado mas vazio (about:blank fallback)
-    try {
-      const doc = iframeRef.current?.contentDocument;
-      if (!doc || doc.body?.innerHTML === "") {
-        setIframeState("blocked");
-      } else {
-        setIframeState("ready");
-      }
-    } catch {
-      // Cross-origin throw = site carregou mas bloqueia acesso ao DOM = OK, está visível
-      setIframeState("ready");
-    }
+    setIframeState("ready");
   }, []);
 
   const handleIframeError = useCallback(() => {
@@ -110,15 +99,15 @@ const LivePreviewModal = ({ url, title, isOpen, onClose }) => {
           {iframeState === "loading" && (
             <div className="lpm-state lpm-state--loading" aria-live="polite">
               <div className="lpm-spinner">
-                <svg width="40" height="40" viewBox="0 0 40 40">
+                <svg width="56" height="56" viewBox="0 0 40 40">
                   <circle cx="20" cy="20" r="16" fill="none" stroke="rgba(74,222,128,0.15)" strokeWidth="3"/>
                   <circle cx="20" cy="20" r="16" fill="none" stroke="#4ade80" strokeWidth="3"
                     strokeDasharray="60 40" strokeLinecap="round"/>
                 </svg>
               </div>
-              <p className="lpm-state__title">Conectando ao servidor</p>
+              <p className="lpm-state__title">Acordando o servidor...</p>
               <p className="lpm-state__sub">
-                O Render pode demorar ~30s para acordar na primeira requisição.
+                Servidores gratuitos hibernam quando inativos. Aguarde até 60 segundos na primeira requisição.
               </p>
             </div>
           )}

--- a/MyWebPortifolio/frontend/src/styles/live-preview-modal.css
+++ b/MyWebPortifolio/frontend/src/styles/live-preview-modal.css
@@ -192,7 +192,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
+  gap: 20px;
   padding: 40px;
   z-index: 2;
   animation: lpm-fade-in 0.3s ease-out forwards;
@@ -200,20 +200,22 @@
 
 .lpm-state__title {
   font-family: 'JetBrains Mono', monospace;
-  font-size: 1rem;
-  font-weight: 600;
-  color: #e2e8f0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #4ade80;
+  text-shadow: 0 0 18px rgba(74, 222, 128, 0.45);
   margin: 0;
   text-align: center;
+  letter-spacing: 0.02em;
 }
 
 .lpm-state__sub {
-  font-size: 0.85rem;
-  color: rgba(255,255,255,0.4);
+  font-size: 0.92rem;
+  color: rgba(255,255,255,0.65);
   margin: 0;
   text-align: center;
-  line-height: 1.6;
-  max-width: 380px;
+  line-height: 1.7;
+  max-width: 420px;
 }
 
 /* Spinner */


### PR DESCRIPTION
## Summary

- Remove verificação de `body.innerHTML` que causava falso positivo em sites cross-origin (ex: Swagger UI)
- `onLoad` agora define estado como `ready` diretamente; `onError` e timeout de 60s tratam `blocked`
- Aumenta timeout de fallback de 8s para 60s (Render free tier pode demorar ~50s para acordar)
- Atualiza textos do estado de loading para comunicar hibernação do servidor
- Melhora destaque visual do loading: título verde com glow, subtítulo mais legível, spinner maior

## Test plan

- [ ] Abrir live preview de projeto com `liveUrl` (ex: Swagger) — deve carregar sem mostrar "bloqueado"
- [ ] Abrir live preview de site que bloqueia iframe (ex: GitHub) — deve mostrar estado "bloqueado"
- [ ] Aguardar 60s sem resposta — deve exibir estado "bloqueado" como fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)