### PR TITLE
fix: profile dropdown layout overflow on mobile

### DIFF
--- a/MyWebPortifolio/frontend/src/styles/header.css
+++ b/MyWebPortifolio/frontend/src/styles/header.css
@@ -698,11 +698,11 @@
   .hdr-hamburger { display: flex; }
 
   .hdr-inner {
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: auto auto;
     padding: 0 18px;
   }
 
-  .hdr-actions { gap: 8px; }
+  .hdr-actions { gap: 8px; justify-content: flex-end;}
 
   .hdr-user-name   { display: none; }
   .hdr-chevron     { display: none; }


### PR DESCRIPTION
O problema acontecia apenas na versão mobile do header.

O grid-template-columns estava funcional, porém a área .hdr-actions ocupava metade do espaço disponível do grid e os elementos começavam alinhados ao início da coluna. Isso fazia com que o layout do menu ficasse desalinhado e causasse o overflow visual no dropdown do perfil.

Adicionei `justify-content: flex-end;`  na, media query, classe .hdr-actions para alinhar os elementos ao final da coluna, aproveitando corretamente o espaço disponível no mobile e evitando que o menu ultrapassasse o limite visual da tela.

### Antes
<img width="511" height="128" alt="image" src="https://github.com/user-attachments/assets/de0cf007-c615-4062-8e73-25cffe950e74" />

#### Depois

<img width="511" height="128" alt="image" src="https://github.com/user-attachments/assets/87811b1f-0664-452c-87b4-f019b6f8edcf" />


## Código

<img width="776" height="573" alt="Correct" src="https://github.com/user-attachments/assets/c5010eb4-3ce9-4a49-9b67-a3fc2611132c" />
